### PR TITLE
Fix build error on ROS 2 humble

### DIFF
--- a/odometry/odometry.h
+++ b/odometry/odometry.h
@@ -90,7 +90,7 @@ namespace champ
                 }
             }
 
-            void getVelocities(champ::Velocities &vel, Time now = now())
+            void getVelocities(champ::Velocities &vel, Time now = champ::Odometry::now())
             {      
                 //if all legs are on the ground, nothing to calculate
                 //or if no legs are on the ground, probably the robot is upside-down


### PR DESCRIPTION
This pull request fixes the following error while `colcon build`
```
--- stderr: champ_base                                 
In file included from /home/ubuntu/ros2_ws/src/champ/champ_base/include/state_estimation.h:35,
                 from /home/ubuntu/ros2_ws/src/champ/champ_base/src/state_estimation.cpp:28:
/home/ubuntu/ros2_ws/install/champ/include/champ/odometry/odometry.h:93:67: error: parameter ‘now’ may not appear in this context
   93 |             void getVelocities(champ::Velocities &vel, Time now = now())
      |                                                                   ^~~
gmake[2]: *** [CMakeFiles/state_estimation.dir/build.make:76: CMakeFiles/state_estimation.dir/src/state_estimation.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:251: CMakeFiles/state_estimation.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< champ_base [14.4s, exited with code 2]
```